### PR TITLE
fix(deps): bump minipass

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "index.js"
   ],
   "dependencies": {
-    "minipass": "3.1.6",
+    "minipass": "3.3.6",
     "tap-parser": "^10.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
updates minipass, as the currently used version has a bug which prevents it from correctly finishing